### PR TITLE
Added Style/StringLiterals to ensure ConsistentQuotesInMultiline.

### DIFF
--- a/config/rubocop-style.yml
+++ b/config/rubocop-style.yml
@@ -95,6 +95,12 @@ Style/Semicolon:
   Enabled: true
   AllowAsExpressionSeparator: true
 
+Style/StringLiterals:
+  Description: Checks if uses of quotes match the configured preference.
+  Enabled: true
+  EnforcedStyle: single_quotes
+  ConsistentQuotesInMultiline: true
+
 Style/TrivialAccessors:
   Description: Checks for trivial reader/writer methods, that c`ould have been created with the
     attr_* family of functions automatically.


### PR DESCRIPTION
@erezny I don't want you to think that this is against the presentation you did yesterday or anything like that! 🤣 is bad timing! I was just looking to add `ConsistentQuotesInMultiline` to it so this change keeps everything about the quotes as is but adds `ConsistentQuotesInMultiline: true`. I encountered this yesterday when doing a multiline string:

Without this change:
This fails
```
 "#{invitation.sender&.first_name} invited you to join their team on Sendoso, are "\
        "you still interested?"
```
because wants:
```
 "#{invitation.sender&.first_name} invited you to join their team on Sendoso, are "\
        'you still interested?'
```

Which I think looks pretty bad.

With this change, this will be correct:
```
 "#{invitation.sender&.first_name} invited you to join their team on Sendoso, are "\
        "you still interested?"
```
