### PR TITLE
change default Metrics/ParameterLists:CountKeywordArgs to false

### DIFF
--- a/config/rubocop-metrics.yml
+++ b/config/rubocop-metrics.yml
@@ -9,3 +9,6 @@ Metrics/BlockLength:
 Metrics/MethodLength:
   Description: Checks if the length of a method exceeds some maximum value.
   Enabled: false
+
+Metrics/ParameterLists:
+  CountKeywordArgs: false


### PR DESCRIPTION
Override Rubocop default Metrics/ParameterList:CountKeywordArgs from `true` to `false`

Reason:
Optional parameters, especially named parameters as preferred over an `options` hash should not count against the 5 argument limit

Cop: https://docs.rubocop.org/rubocop/cops_metrics.html#metricsparameterlists

Basis of cop: https://rubystyle.guide/#too-many-params (does not give explicit opinion on counting named parameters)

Example where the current config is problematic: https://github.com/sendoso/sending-api/pull/61/files#diff-766e879d0e49feb1ce1d994a074cff0c667b9262f748500b510c05cb60bac57aR11-R21