### PR TITLE
require trailing comma in multiline hash literal

### DIFF
--- a/config/rubocop-style.yml
+++ b/config/rubocop-style.yml
@@ -101,6 +101,11 @@ Style/StringLiterals:
   EnforcedStyle: single_quotes
   ConsistentQuotesInMultiline: true
 
+Style/TrailingCommaInHashLiteral:
+  Description: Checks for trailing comma in hash literals
+  Enabled: true
+  EnforcedStyleForMultiline: consistent_comma
+
 Style/TrivialAccessors:
   Description: Checks for trivial reader/writer methods, that c`ould have been created with the
     attr_* family of functions automatically.

--- a/config/rubocop-style.yml
+++ b/config/rubocop-style.yml
@@ -101,6 +101,11 @@ Style/StringLiterals:
   EnforcedStyle: single_quotes
   ConsistentQuotesInMultiline: true
 
+Style/TrailingCommaInArrayLiteral:
+  Description: Checks for trailing comma in array literals
+  Enabled: true
+  EnforcedStyleForMultiline: consistent_comma
+
 Style/TrailingCommaInHashLiteral:
   Description: Checks for trailing comma in hash literals
   Enabled: true


### PR DESCRIPTION
# Description
Override Rubocop default Style/TrailingCommaInHashLiteral from `no_comma` to `consistent_comma`

(will add commit for Style/TrailingCommaInArrayLiteral)

# Motivation
Trailing comma in some languages (not Ruby) is a syntactic error, or results in an extra `undefined` element in the collection.
Ruby does not have either of these issues.
When trailing comma on multiline collections is required, the final element(s) does not require modification (as per git history) when adding or removing an element.

Rubocop has separate similar rules for [Arguments](https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/TrailingCommaInArguments) [guide](https://rubystyle.guide/#no-trailing-params-comma) and [Blocks](https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/TrailingCommaInBlockArgs) [guide](https://rubystyle.guide/#no-trailing-parameters-comma). I would keep the `no_comma` rule there as changes often imply the signature of the call has also changed.
In my first example below, I extracted the implicit-hash argument of `.new` to an a valid array before passing it to `new`

# Cop(s)
* https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/TrailingCommaInHashLiteral
* https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/TrailingCommaInArrayLiteral

# Basis of cop(s)
* https://rubystyle.guide/#no-trailing-array-commas (both Array and Hash)

# Example(s) where the current config is problematic
* https://github.com/sendoso/sending-api/pull/65/files#diff-4ae4271f4004c756c7ffeb1152a12797fe54000cfa428341fe5faa03802b7efaR56-R60
* https://github.com/sendoso/sendoso/blob/ee3b0c663ac6456dc34484edc04b54e8d2d8dbb5/app/models/activity_transaction.rb#L66-L86
* many others