### PR TITLE
Update rubocop-rails.yml

### DIFF
--- a/config/rubocop-rails.yml
+++ b/config/rubocop-rails.yml
@@ -26,3 +26,6 @@ Rails/SkipsModelValidations:
   Description: This cop checks for the use of methods which skip validations which are listed in
     guides.rubyonrails.org/active_record_validations.html#skipping-validations
   Enabled: true
+  Exclude:
+    - spec/**/*
+    - db/data/**/*

--- a/lib/rubocop/sendoso/version.rb
+++ b/lib/rubocop/sendoso/version.rb
@@ -2,6 +2,6 @@
 
 module Rubocop
   module Sendoso
-    VERSION = '0.1.4'
+    VERSION = '0.1.6'
   end
 end


### PR DESCRIPTION
Disable SkipsModelValidations in both specs and in data migrations.
Specs are disabled in monolith, and seems like a sensible default.
We also purposefully update data bypassing validations in data migrations, so it makes sense to relax this requirement(even if we may prefer to use validations where possible)