### PR TITLE
[SDQ-2009] lint missing super

### DIFF
--- a/config/rubocop-lint.yml
+++ b/config/rubocop-lint.yml
@@ -16,6 +16,12 @@ Lint/ErbNewArguments:
   Description: Emulates warnings in Ruby 2.6
   Enabled: true
 
+Lint/MissingSuper:
+  Description: Checks for the presence of constructors and lifecycle callbacks without calls to ‘super`.
+  Enabled: true
+  Exclude:
+    - app/services/**/*
+
 Lint/RedundantStringCoercion:
   Description: Checks for Object#to_s usage in string interpolation.
   Enabled: true

--- a/lib/rubocop/sendoso/version.rb
+++ b/lib/rubocop/sendoso/version.rb
@@ -2,6 +2,6 @@
 
 module Rubocop
   module Sendoso
-    VERSION = '0.1.6'
+    VERSION = '0.1.7'
   end
 end


### PR DESCRIPTION
Remove enforcement of Lint/MissingSuper for app/services directory and subdirectories, matching overrides in monolith.