### PR TITLE
[GROW-1780] Enforce double quotes strings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
           ruby-version: 3.1
           bundler-cache: true
 
-      - name: 'Setup Gem Credentials'
+      - name: "Setup Gem Credentials"
         run: |
           mkdir -p $HOME/.gem
           touch $HOME/.gem/credentials
@@ -27,7 +27,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GPR_WRITEONLY_TOKEN }}
 
-      - name: 'Publish Gem'
+      - name: "Publish Gem"
         run: |
           bundle exec gem bump -v ${RELEASE_TAG#"v"} --no-commit
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: Rubocop + RSpec
 on:
   push:
     branches:
-      - '**'
+      - "**"
     tags-ignore:
-      - 'v*'
+      - "v*"
 
 env:
   BUNDLE_RUBYGEMS__PKG__GITHUB__COM: ${{secrets.GPR_READONLY_TOKEN}}
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby-version: ['3.1', '3.0', '2.7', '2.6']
+        ruby-version: ["3.1", "3.0", "2.7", "2.6"]
 
     steps:
       - uses: actions/checkout@v3

--- a/Gemfile
+++ b/Gemfile
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
 # Specify your gem's dependencies in rubocop-sendoso.gemspec
 gemspec
 
-gem 'rake', '~> 13.0'
+gem "rake", "~> 13.0"
 
-gem 'rspec', '~> 3.0'
+gem "rspec", "~> 3.0"
 
-gem 'debug'
-gem 'gem-release'
-gem 'webmock'
+gem "debug"
+gem "gem-release"
+gem "webmock"

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ important that the tag you create be named properly.
 > * v1.0.0
 
 Sendoso uses [semantic versioning](https://semver.org/) to version gems (`<major>.<minor>.<patch>`).
-The rule of them for incrementing versions is as follows:
+The rule of thumb for incrementing versions is as follows:
 
 | Version Bump | Description |
 | ---- | ---- |

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ tag:
 
 ```ruby
 group :development do
-  gem 'rubocop-sendoso', github: 'sendoso/rubocop-sendoso', tag: 'vx.x.x', require: false
+  gem "rubocop-sendoso", github: "sendoso/rubocop-sendoso", tag: "vx.x.x", require: false
 end
 ```
 
@@ -56,7 +56,7 @@ The ruby gem version is based entirely off of the git tag in your release. There
 important that the tag you create be named properly.
 
 > Tags:
-> * **MUST** start with 'v'
+> * **MUST** start with "v"
 > * **MUST** container major, minor, and patch number
 >
 > Examples:

--- a/Rakefile
+++ b/Rakefile
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-require 'bundler/gem_tasks'
-require 'rspec/core/rake_task'
+require "bundler/gem_tasks"
+require "rspec/core/rake_task"
 
 RSpec::Core::RakeTask.new(:spec)
 
-require 'rubocop/rake_task'
+require "rubocop/rake_task"
 
 RuboCop::RakeTask.new
 

--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -1628,7 +1628,7 @@ In either case:
 > too.
 
 > The point of having style guidelines is to have a common vocabulary of coding
-> so people can concentrate on what you"re saying rather than on how you"re
+> so people can concentrate on what you're saying rather than on how you're
 > saying it. We present global style rules here so people know the vocabulary,
 > but local style is also important. If code you add to a file looks
 > drastically different from the existing code around it, it throws readers out

--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -42,10 +42,10 @@
 
     ```ruby
     case
-    when song.name == 'Misty'
-      puts 'Not again!'
+    when song.name == "Misty"
+      puts "Not again!"
     when song.duration > 120
-      puts 'Too long!'
+      puts "Too long!"
     when Time.now.hour > 21
       puts "It's too late"
     else
@@ -53,12 +53,12 @@
     end
 
     kind = case year
-           when 1850..1889 then 'Blues'
-           when 1890..1909 then 'Ragtime'
-           when 1910..1929 then 'New Orleans Jazz'
-           when 1930..1939 then 'Swing'
-           when 1940..1950 then 'Bebop'
-           else 'Jazz'
+           when 1850..1889 then "Blues"
+           when 1890..1909 then "Ragtime"
+           when 1910..1929 then "New Orleans Jazz"
+           when 1930..1939 then "Swing"
+           when 1940..1950 then "Bebop"
+           else "Jazz"
            end
     ```
 
@@ -140,7 +140,7 @@
     ```ruby
     sum = 1 + 2
     a, b = 1, 2
-    1 > 2 ? true : false; puts 'Hi'
+    1 > 2 ? true : false; puts "Hi"
     [1, 2, 3].each { |e| puts e }
     ```
 
@@ -509,10 +509,10 @@ Thus when you create a TODO, it is almost always your name that is given.
 
     ```ruby
     # okay
-    render(:partial => 'foo')
+    render(:partial => "foo")
 
     # okay
-    render :partial => 'foo'
+    render :partial => "foo"
     ```
 
 In either case:
@@ -523,10 +523,10 @@ In either case:
 
     ```ruby
     # bad
-    get '/v1/reservations', { :id => 54875 }
+    get "/v1/reservations", { :id => 54875 }
 
     # good
-    get '/v1/reservations', :id => 54875
+    get "/v1/reservations", :id => 54875
     ```
 
 ## Conditional Expressions
@@ -604,16 +604,16 @@ In either case:
     ```ruby
     # bad
     unless success?
-      puts 'failure'
+      puts "failure"
     else
-      puts 'success'
+      puts "success"
     end
 
     # good
     if success?
-      puts 'success'
+      puts "success"
     else
-      puts 'failure'
+      puts "failure"
     end
     ```
 
@@ -833,13 +833,13 @@ In either case:
     # good
     names.each do |name|
       puts name
-      puts 'yay!'
+      puts "yay!"
     end
 
     # bad
     names.each { |name|
       puts name
-      puts 'yay!'
+      puts "yay!"
     }
 
     # good
@@ -883,16 +883,16 @@ In either case:
 
     ```ruby
     # bad
-    puts 'foobar'; # superfluous semicolon
-    puts 'foo'; puts 'bar' # two expressions on the same line
+    puts "foobar"; # superfluous semicolon
+    puts "foo"; puts "bar" # two expressions on the same line
 
     # good
-    puts 'foobar'
+    puts "foobar"
 
-    puts 'foo'
-    puts 'bar'
+    puts "foo"
+    puts "bar"
 
-    puts 'foo', 'bar' # this applies to puts in particular
+    puts "foo", "bar" # this applies to puts in particular
     ```
 
 * <a name="colon-use"></a>Use :: only to reference constants(this includes
@@ -953,7 +953,7 @@ In either case:
 
     ```ruby
     # set name to Bozhidar, only if it's nil or false
-    name ||= 'Bozhidar'
+    name ||= "Bozhidar"
     ```
 
 * <a name="no-double-pipes-for-bools"></a>Don't use `||=` to initialize boolean
@@ -1035,9 +1035,9 @@ In either case:
     ```ruby
     # bad
     class Color
-      RED = 'red'
-      BLUE = 'blue'
-      GREEN = 'green'
+      RED = "red"
+      BLUE = "blue"
+      GREEN = "green"
 
       ALL_COLORS = [
         RED,
@@ -1054,9 +1054,9 @@ In either case:
 
     # good
     class Color
-      RED = 'red'.freeze
-      BLUE = 'blue'.freeze
-      GREEN = 'green'.freeze
+      RED = "red".freeze
+      BLUE = "blue".freeze
+      GREEN = "green".freeze
 
       ALL_COLORS = [
         RED,
@@ -1098,8 +1098,8 @@ In either case:
     <sup>[[link](#throwaway-variables)]</sup>
 
     ```ruby
-    version = '3.2.1'
-    major_version, minor_version, _ = version.split('.')
+    version = "3.2.1"
+    major_version, minor_version, _ = version.split(".")
     ```
 
 ## Classes
@@ -1110,7 +1110,7 @@ In either case:
 
     ```ruby
     class Parent
-      @@class_var = 'parent'
+      @@class_var = "parent"
 
       def self.print_class_var
         puts @@class_var
@@ -1118,7 +1118,7 @@ In either case:
     end
 
     class Child < Parent
-      @@class_var = 'child'
+      @@class_var = "child"
     end
 
     Parent.print_class_var # => will print "child"
@@ -1248,10 +1248,10 @@ In either case:
 
     ```ruby
     # bad
-    raise RuntimeError, 'message'
+    raise RuntimeError, "message"
 
     # better - RuntimeError is implicit here
-    raise 'message'
+    raise "message"
 
     # best
     class MyExplicitError < RuntimeError; end
@@ -1266,12 +1266,12 @@ In either case:
 
     ```Ruby
     # bad
-    raise SomeException.new('message')
-    # Note that there is no way to do `raise SomeException.new('message'), backtrace`.
+    raise SomeException.new("message")
+    # Note that there is no way to do `raise SomeException.new("message"), backtrace`.
 
     # good
-    raise SomeException, 'message'
-    # Consistent with `raise SomeException, 'message', backtrace`.
+    raise SomeException, "message"
+    # Consistent with `raise SomeException, "message", backtrace`.
     ```
 
 
@@ -1328,12 +1328,12 @@ In either case:
 
     ```ruby
     # bad
-    %w(one two three) * ', '
-    # => 'one, two, three'
+    %w(one two three) * ", "
+    # => "one, two, three"
 
     # good
-    %w(one two three).join(', ')
-    # => 'one, two, three'
+    %w(one two three).join(", ")
+    # => "one, two, three"
     ```
 
 * <a name="symbol-keys"></a>Use symbols instead of strings as hash keys.
@@ -1341,7 +1341,7 @@ In either case:
 
     ```ruby
     # bad
-    hash = { 'one' => 1, 'two' => 2, 'three' => 3 }
+    hash = { "one" => 1, "two" => 2, "three" => 3 }
 
     # good
     hash = { :one => 1, :two => 2, :three => 3 }
@@ -1380,7 +1380,7 @@ In either case:
 
     ```ruby
     hash = {
-      :protocol => 'https',
+      :protocol => "https",
       :only_path => false,
       :controller => :users,
       :action => :set_password,
@@ -1412,7 +1412,7 @@ In either case:
 
     ```ruby
     # bad
-    email_with_name = user.name + ' <' + user.email + '>'
+    email_with_name = user.name + " <" + user.email + ">"
 
     # good
     email_with_name = "#{user.name} <#{user.email}>"
@@ -1422,7 +1422,7 @@ In either case:
   composing cache keys like this:
 
     ```ruby
-    CACHE_KEY = '_store'
+    CACHE_KEY = "_store"
 
     cache.write(@user.id + CACHE_KEY)
     ```
@@ -1430,7 +1430,7 @@ In either case:
     Prefer string interpolation instead of string concatenation:
 
     ```ruby
-    CACHE_KEY = '%d_store'
+    CACHE_KEY = "%d_store"
 
     cache.write(CACHE_KEY % @user.id)
     ```
@@ -1442,8 +1442,8 @@ In either case:
 
     ```ruby
     # good and also fast
-    story = ''
-    story << 'The Ugly Duckling'
+    story = ""
+    story << "The Ugly Duckling"
 
     paragraphs.each do |paragraph|
       story << paragraph
@@ -1539,7 +1539,7 @@ In either case:
     ```ruby
     # bad - no interpolation needed
     %(Welcome, Jane!)
-    # should be 'Welcome, Jane!'
+    # should be "Welcome, Jane!"
 
     # bad - no double-quotes
     %(This is #{quality} style)
@@ -1554,7 +1554,7 @@ In either case:
     ```
 
 * <a name="percent-r"></a>Use `%r` only for regular expressions matching *more
-    than* one '/' character.<sup>[[link](#percent-r)]</sup>
+    than* one "/" character.<sup>[[link](#percent-r)]</sup>
 
     ```ruby
     # bad
@@ -1589,18 +1589,18 @@ In either case:
 
     ```ruby
     # bad
-    render :text => 'Howdy' and return
+    render :text => "Howdy" and return
 
     # good
-    render :text => 'Howdy'
+    render :text => "Howdy"
     return
 
     # still bad
-    render :text => 'Howdy' and return if foo.present?
+    render :text => "Howdy" and return if foo.present?
 
     # good
     if foo.present?
-      render :text => 'Howdy'
+      render :text => "Howdy"
       return
     end
     ```
@@ -1628,7 +1628,7 @@ In either case:
 > too.
 
 > The point of having style guidelines is to have a common vocabulary of coding
-> so people can concentrate on what you're saying rather than on how you're
+> so people can concentrate on what you"re saying rather than on how you"re
 > saying it. We present global style rules here so people know the vocabulary,
 > but local style is also important. If code you add to a file looks
 > drastically different from the existing code around it, it throws readers out

--- a/bin/setup
+++ b/bin/setup
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
-IFS=$'\n\t'
+IFS=$"\n\t"
 set -vx
 
 bundle install

--- a/config/default.yml
+++ b/config/default.yml
@@ -1,13 +1,13 @@
 
 AllCops:
   Exclude:
-    - 'bin/**/*'
-    - 'db/**/*'
-    - 'node_modules/**/*'
-    - '**/vendor/**/*'
-    - '**/vendor/**/.*'
-    - '.git/**/*'
-    - '**/schema.rb'
+    - "bin/**/*"
+    - "db/**/*"
+    - "node_modules/**/*"
+    - "**/vendor/**/*"
+    - "**/vendor/**/.*"
+    - ".git/**/*"
+    - "**/schema.rb"
 
   DefaultFormatter: progress
   DisplayCopNames: true

--- a/config/rubocop-style.yml
+++ b/config/rubocop-style.yml
@@ -166,7 +166,7 @@ Style/Semicolon:
 Style/StringLiterals:
   Description: Checks if uses of quotes match the configured preference.
   Enabled: true
-  EnforcedStyle: single_quotes
+  EnforcedStyle: double_quotes
   ConsistentQuotesInMultiline: true
 
 Style/TrailingCommaInArrayLiteral:

--- a/lib/rubocop/sendoso.rb
+++ b/lib/rubocop/sendoso.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative 'sendoso/version'
+require_relative "sendoso/version"
 
 module Rubocop
   module Sendoso

--- a/lib/rubocop/sendoso/command.rb
+++ b/lib/rubocop/sendoso/command.rb
@@ -1,6 +1,6 @@
-require 'thor'
+require "thor"
 
-require 'rubocop/sendoso'
+require "rubocop/sendoso"
 
 module Rubocop
   module Sendoso
@@ -12,14 +12,14 @@ module Rubocop
         true
       end
 
-      desc 'version', 'Get the version of rubocop-sendoso'
-      option :plain, type: :boolean, default: false, aliases: ['-p']
+      desc "version", "Get the version of rubocop-sendoso"
+      option :plain, type: :boolean, default: false, aliases: ["-p"]
       def version
         return puts Rubocop::Sendoso::VERSION if options[:plain]
 
         puts "rubocop-sendoso version: #{Rubocop::Sendoso::VERSION}"
       end
-      map ['-v', '--version'] => :version
+      map ["-v", "--version"] => :version
     end
   end
 end

--- a/lib/rubocop/sendoso/version.rb
+++ b/lib/rubocop/sendoso/version.rb
@@ -2,6 +2,6 @@
 
 module Rubocop
   module Sendoso
-    VERSION = "0.1.8"
+    VERSION = "0.2.0"
   end
 end

--- a/lib/rubocop/sendoso/version.rb
+++ b/lib/rubocop/sendoso/version.rb
@@ -2,6 +2,6 @@
 
 module Rubocop
   module Sendoso
-    VERSION = '0.1.7'
+    VERSION = '0.1.8'
   end
 end

--- a/lib/rubocop/sendoso/version.rb
+++ b/lib/rubocop/sendoso/version.rb
@@ -2,6 +2,6 @@
 
 module Rubocop
   module Sendoso
-    VERSION = '0.1.8'
+    VERSION = "0.1.8"
   end
 end

--- a/rubocop-sendoso.gemspec
+++ b/rubocop-sendoso.gemspec
@@ -1,32 +1,32 @@
 # frozen_string_literal: true
 
-require_relative 'lib/rubocop/sendoso/version'
+require_relative "lib/rubocop/sendoso/version"
 
 Gem::Specification.new do |spec|
-  spec.name          = 'rubocop-sendoso'
+  spec.name          = "rubocop-sendoso"
   spec.version       = Rubocop::Sendoso::VERSION
-  spec.authors       = ['Sendoso']
-  spec.email         = ['engineering@sendoso.com']
+  spec.authors       = ["Sendoso"]
+  spec.email         = ["engineering@sendoso.com"]
 
-  spec.summary       = 'RuboCop Sendoso'
-  spec.description   = 'Code style checking for Sendoso Ruby repositories'
-  spec.homepage      = 'https://github.com/sendoso/rubocop-sendoso'
-  spec.license       = 'MIT'
-  spec.required_ruby_version = '>= 2.6.6'
+  spec.summary       = "RuboCop Sendoso"
+  spec.description   = "Code style checking for Sendoso Ruby repositories"
+  spec.homepage      = "https://github.com/sendoso/rubocop-sendoso"
+  spec.license       = "MIT"
+  spec.required_ruby_version = ">= 2.6.6"
 
-  spec.metadata['allowed_push_host'] = 'https://rubygems.pkg.github.com/sendoso'
+  spec.metadata["allowed_push_host"] = "https://rubygems.pkg.github.com/sendoso"
 
-  spec.metadata['homepage_uri'] = spec.homepage
-  spec.metadata['source_code_uri'] = 'https://github.com/sendoso/rubocop-sendoso'
-  spec.metadata['changelog_uri'] = 'https://github.com/sendoso/rubocop-sendoso'
+  spec.metadata["homepage_uri"] = spec.homepage
+  spec.metadata["source_code_uri"] = "https://github.com/sendoso/rubocop-sendoso"
+  spec.metadata["changelog_uri"] = "https://github.com/sendoso/rubocop-sendoso"
 
-  spec.files = Dir['README.md', 'STYLEGUIDE.md', 'LICENSE', 'config/*.yml', 'lib/**/*.rb']
-  spec.require_paths = ['lib']
+  spec.files = Dir["README.md", "STYLEGUIDE.md", "LICENSE", "config/*.yml", "lib/**/*.rb"]
+  spec.require_paths = ["lib"]
 
   # Gem dependencies
-  spec.add_dependency('rubocop', '~> 1.17')
-  spec.add_dependency('rubocop-rails', '~> 2.11')
-  spec.add_dependency('rubocop-rspec', '~> 2.4')
+  spec.add_dependency("rubocop", "~> 1.17")
+  spec.add_dependency("rubocop-rails", "~> 2.11")
+  spec.add_dependency("rubocop-rspec", "~> 2.4")
 
   # For more information and examples about making a new gem, checkout our
   # guide at: https://bundler.io/guides/creating_gem.html

--- a/spec/rubocop/sendoso_spec.rb
+++ b/spec/rubocop/sendoso_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe Rubocop::Sendoso do
-  it 'has a version number' do
+  it "has a version number" do
     expect(Rubocop::Sendoso::VERSION).not_to be nil
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
-require 'webmock/rspec'
-require 'rubocop/sendoso'
+require "webmock/rspec"
+require "rubocop/sendoso"
 
 WebMock.disable_net_connect!(allow_localhost: true)
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
-  config.example_status_persistence_file_path = '.rspec_status'
+  config.example_status_persistence_file_path = ".rspec_status"
 
   # Disable RSpec exposing methods globally on `Module` and `main`
   config.disable_monkey_patching!


### PR DESCRIPTION
Jira: https://sendoso.atlassian.net/browse/GROW-1780

## Description
Just upgraded Sendoso core from `6.0` to `6.1` and ran `rails app:update`. Noticed the files in `bin` mostly changed to double quotes but rubocop is raising errors for those double quote strings due to default check. So we should disable this rule in `.rubcop.yml`
```yml
Style/StringLiterals:
  Enabled: true
  EnforcedStyle: double_quotes # enforce double quote
  
```
As a first step, we will enforce `double_quotes`, then gradually update all single quotes to double quotes within our projects. 

## Motivation and Context
Rails community preferred single quotes over double quotes when no interpolation is required to improve the performance **BUT** in a recent couple of years, there has been no meaningful performance difference in using double quotes over single quotes. 
https://www.viget.com/articles/just-use-double-quoted-ruby-strings/
https://anti-pattern.com/always-use-double-quoted-strings-in-ruby
Also, Rails 7 has started using double quotes instead of single quotes. See https://github.com/rails/rails/pull/42064.

## How Has This Been Tested?
Rubocop shouldn't raise errors on string with double quotes. For example
```ruby
require "rails/commands"
```

