### PR TITLE
[GROW-5652] Security: Update rubocop-rails to 2.27+

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ on:
   release:
     types:
       - released
+      - prereleased
 
 env:
   BUNDLE_RUBYGEMS__PKG__GITHUB__COM: ${{secrets.GPR_READONLY_TOKEN}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby-version: ["3.1", "3.0", "2.7", "2.6"]
+        ruby-version: ["3.2", "3.1"]
 
     steps:
       - uses: actions/checkout@v3

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,10 +1,9 @@
-
 inherit_from:
   - ./config/default.yml
 
 AllCops:
   CacheRootDirectory: tmp/rubocop
-  TargetRubyVersion: 3.1
+  TargetRubyVersion: 3.1.7
 
 Rails:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,7 @@ inherit_from:
 
 AllCops:
   CacheRootDirectory: tmp/rubocop
-  TargetRubyVersion: 2.6.6
+  TargetRubyVersion: 3.1
 
 Rails:
   Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,7 @@
 ## [0.1.0] - 2021-06-04
 
 - Initial release
+
+## [0.2.1] - 2025-04-07
+### Security
+- Updated rubocop-rails dependency to >= 2.27.0 to address Rack security vulnerabilities (CVE-2025-27610, CVE-2025-25184, CVE-2025-27111)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 - Initial release
 
-## [0.2.1] - 2025-04-07
+## [1.0.0] - 2025-04-07
+### Breaking Changes
+- Updated required Ruby version to 3.1.7
+- Updated RuboCop dependency to ~> 1.75.2
+- Updated rubocop-rails dependency to ~> 2.31.0
+- Updated rubocop-rspec dependency to ~> 3.5.0
+
 ### Security
-- Updated rubocop-rails dependency to >= 2.27.0 to address Rack security vulnerabilities (CVE-2025-27610, CVE-2025-25184, CVE-2025-27111)
+- Updated rubocop-rails dependency to ~> 2.27 to address Rack security vulnerabilities (CVE-2025-27610, CVE-2025-25184, CVE-2025-27111)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   gem:
     container_name: rubocop-sendoso-gem
-    image: ruby:3.1
+    image: ruby:3.1.7
     init: true
     working_dir: /app
     environment:

--- a/lib/rubocop/sendoso/version.rb
+++ b/lib/rubocop/sendoso/version.rb
@@ -2,6 +2,6 @@
 
 module Rubocop
   module Sendoso
-    VERSION = "0.3.0"
+    VERSION = "1.0.0"
   end
 end

--- a/lib/rubocop/sendoso/version.rb
+++ b/lib/rubocop/sendoso/version.rb
@@ -2,6 +2,6 @@
 
 module Rubocop
   module Sendoso
-    VERSION = "0.2.0"
+    VERSION = "0.2.1"
   end
 end

--- a/lib/rubocop/sendoso/version.rb
+++ b/lib/rubocop/sendoso/version.rb
@@ -2,6 +2,6 @@
 
 module Rubocop
   module Sendoso
-    VERSION = "0.2.1"
+    VERSION = "0.3.0"
   end
 end

--- a/rubocop-sendoso.gemspec
+++ b/rubocop-sendoso.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   # Gem dependencies
-  spec.add_dependency("rubocop", "~> 1.17")
+  spec.add_dependency("rubocop", "~> 1.67")
   spec.add_dependency("rubocop-rails", "~> 2.27")
   spec.add_dependency("rubocop-rspec", "~> 2.4")
 

--- a/rubocop-sendoso.gemspec
+++ b/rubocop-sendoso.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
 
   # Gem dependencies
   spec.add_dependency("rubocop", "~> 1.17")
-  spec.add_dependency("rubocop-rails", "~> 2.11")
+  spec.add_dependency("rubocop-rails", "~> 2.27")
   spec.add_dependency("rubocop-rspec", "~> 2.4")
 
   # For more information and examples about making a new gem, checkout our

--- a/rubocop-sendoso.gemspec
+++ b/rubocop-sendoso.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description   = "Code style checking for Sendoso Ruby repositories"
   spec.homepage      = "https://github.com/sendoso/rubocop-sendoso"
   spec.license       = "MIT"
-  spec.required_ruby_version = ">= 2.6.6"
+  spec.required_ruby_version = ">= 3.1.0"
 
   spec.metadata["allowed_push_host"] = "https://rubygems.pkg.github.com/sendoso"
 

--- a/rubocop-sendoso.gemspec
+++ b/rubocop-sendoso.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description   = "Code style checking for Sendoso Ruby repositories"
   spec.homepage      = "https://github.com/sendoso/rubocop-sendoso"
   spec.license       = "MIT"
-  spec.required_ruby_version = "3.1.7"
+  spec.required_ruby_version = ">= 3.1.6"
 
   spec.metadata["allowed_push_host"] = "https://rubygems.pkg.github.com/sendoso"
 

--- a/rubocop-sendoso.gemspec
+++ b/rubocop-sendoso.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description   = "Code style checking for Sendoso Ruby repositories"
   spec.homepage      = "https://github.com/sendoso/rubocop-sendoso"
   spec.license       = "MIT"
-  spec.required_ruby_version = ">= 3.1.0"
+  spec.required_ruby_version = "3.1.7"
 
   spec.metadata["allowed_push_host"] = "https://rubygems.pkg.github.com/sendoso"
 
@@ -24,9 +24,9 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   # Gem dependencies
-  spec.add_dependency("rubocop", "~> 1.67")
-  spec.add_dependency("rubocop-rails", "~> 2.27")
-  spec.add_dependency("rubocop-rspec", "~> 2.4")
+  spec.add_dependency("rubocop", "~> 1.75.2")
+  spec.add_dependency("rubocop-rails", "~> 2.31.0")
+  spec.add_dependency("rubocop-rspec", "~> 3.5.0")
 
   # For more information and examples about making a new gem, checkout our
   # guide at: https://bundler.io/guides/creating_gem.html

--- a/spec/rubocop/sendoso_spec.rb
+++ b/spec/rubocop/sendoso_spec.rb
@@ -2,6 +2,6 @@
 
 RSpec.describe Rubocop::Sendoso do
   it "has a version number" do
-    expect(Rubocop::Sendoso::VERSION).not_to be nil
+    expect(Rubocop::Sendoso::VERSION).not_to be_nil
   end
 end


### PR DESCRIPTION
- [x] update dependencies to the latest version 
- [x] update version due to breaking changes 