### PR TITLE
[GROW-5652] Updated RuboCop configuration to use plugins instead of require

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,7 @@
 
 ### Security
 - Updated rubocop-rails dependency to ~> 2.27 to address Rack security vulnerabilities (CVE-2025-27610, CVE-2025-25184, CVE-2025-27111)
+
+## [1.0.1] - 2025-04-08
+### Fixed
+- Updated RuboCop configuration to use `plugins` instead of `require` for rubocop-rspec and rubocop-rails extensions

--- a/config/default.yml
+++ b/config/default.yml
@@ -1,4 +1,3 @@
-
 AllCops:
   Exclude:
     - "bin/**/*"
@@ -20,9 +19,9 @@ AllCops:
 Rails:
   Enabled: true
 
-require:
-  - rubocop-rspec
+plugins:
   - rubocop-rails
+  - rubocop-rspec
 
 inherit_from:
   - rubocop-layout.yml

--- a/lib/rubocop/sendoso/version.rb
+++ b/lib/rubocop/sendoso/version.rb
@@ -2,6 +2,6 @@
 
 module Rubocop
   module Sendoso
-    VERSION = "1.0.0"
+    VERSION = "1.0.1"
   end
 end


### PR DESCRIPTION
- [x] Updated RuboCop configuration to use plugins instead of require


![Screenshot 2025-04-08 at 2 47 58 PM](https://github.com/user-attachments/assets/03c78bd8-192a-4afe-8f26-b225ab9fc1f6)
